### PR TITLE
Lighter process kill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+vendor/
+.idea/
+binstubs/

--- a/lib/redis_test.rb
+++ b/lib/redis_test.rb
@@ -74,8 +74,10 @@ module RedisTest
     end
 
     def stop
-      pid = File.read(pidfile).to_i
-      Process.kill("QUIT", pid)
+      if File.file?(pidfile) && File.readable?(pidfile)
+        pid = File.read(pidfile).to_i
+        Process.kill("QUIT", pid) if pid > 0
+      end
       FileUtils.rm_f("#{cache_path}#{db_filename}")
     end
 

--- a/lib/redis_test.rb
+++ b/lib/redis_test.rb
@@ -74,10 +74,9 @@ module RedisTest
     end
 
     def stop
-      %x{
-        cat #{pidfile} | xargs kill -QUIT
-        rm -f #{cache_path}#{db_filename}
-      }
+      pid = File.read(pidfile).to_i
+      Process.kill("QUIT", pid)
+      FileUtils.rm_f("#{cache_path}#{db_filename}")
     end
 
     def server_url


### PR DESCRIPTION
A subtle behavior of the older kill code is that `xargs` does nothing when the pidfile doesn't exists.  This PR adds logic to test for both the readability of the pidfile and that its content is a positive integer.

Jenkins was still failing when the pidfile didn't exist: http://jenkins.corp.apptentive.com/job/Platform_Parameterized_Build/991/console