### PR TITLE
allow specifying redis-server command via environment variable

### DIFF
--- a/lib/redis_test.rb
+++ b/lib/redis_test.rb
@@ -6,6 +6,11 @@ module RedisTest
       (ENV['TEST_REDIS_PORT'] || 9736).to_i
     end
 
+    def redis_server_command
+      ENV['TEST_REDIS_SERVER_COMMAND'] || "redis-server"
+    end
+
+
     def db_filename
       "redis-test-#{port}.rdb"
     end
@@ -54,7 +59,9 @@ module RedisTest
         "loglevel"      => loglevel,
         "databases"     => 16
       }.map { |k, v| "#{k} #{v}" }.join('\n')
-      `echo '#{redis_options}' | redis-server -`
+
+      `echo '#{redis_options}' | '#{redis_server_command}' -`
+
 
       wait_time_remaining = 5
       begin


### PR DESCRIPTION
**Goal**
To allow running multiple versions in controlled environments, eg: circleci doesn't support latest version of redis (3.2.3) yet 

**Feature**
This feature allows specifying running the 'redis-server' command from an alternate location instead of relying on the system path

example: 
TEST_REDIS_SERVER_COMMAND=/Users/xxx/Downloads/redis-3.2.3/src/redis-server rake test
