### PR TITLE
[ready] Allow customize the whole url

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ My approach is very simple, and may be already widely used:
 Start a redis server on port 9736 (can be
 customized by setting `ENV['TEST_REDIS_PORT']`) and simply change your
 config so your redis client will connect there during test instead.
+It's possible to custom the whole url via `ENV["TEST_REDIS_URL"]` also
 
 I just try to package it in a convenient way so I don't have to repeat
 it for every project I use.

--- a/lib/redis_test.rb
+++ b/lib/redis_test.rb
@@ -3,8 +3,17 @@ require 'socket'
 
 module RedisTest
   class << self
+    def find_port
+      @port ||= (ENV["TEST_REDIS_PORT"] || find_available_port).to_i
+    end
+
+    def uri
+      url = ENV["TEST_REDIS_URL"] || "redis://localhost:#{find_port}"
+      URI(url)
+    end
+
     def port
-      @port ||= (ENV['TEST_REDIS_PORT'] || find_available_port).to_i
+      uri.port
     end
 
     def db_filename
@@ -68,7 +77,7 @@ module RedisTest
 
       wait_time_remaining = 5
       begin
-        self.socket = TCPSocket.open("localhost", port)
+        self.socket = TCPSocket.open(uri.host, port)
         clear
         @started = true
       rescue Exception => e
@@ -100,7 +109,7 @@ module RedisTest
     end
 
     def server_url
-      "redis://localhost:#{port}"
+      uri.to_s
     end
 
     def configure(*options)

--- a/lib/redis_test/version.rb
+++ b/lib/redis_test/version.rb
@@ -1,3 +1,3 @@
 module RedisTest
-  VERSION = "0.4.0"
+  VERSION = "0.5.0"
 end


### PR DESCRIPTION
Under Docker, a container can access to Redis in another container by querying this URL: `redis://redis.test:6379`.
With current configuration (default to localhost, only allow the user to set port), the user can't make this work under docker.
Hence I add the ability to allow the user to set the whole URL.