### PR TITLE
[ready] play nice with linux

### DIFF
--- a/lib/redis_test.rb
+++ b/lib/redis_test.rb
@@ -63,7 +63,8 @@ module RedisTest
       redis_options_str = redis_options.map { |k, v| "#{k} #{v}" }.join('\n')
 
       fork do
-        system "echo '#{redis_options_str}' | redis-server -"
+        echo_command = mac? ? 'echo' : 'echo -e'
+        system "#{echo_command} '#{redis_options_str}' | redis-server -"
       end
 
       wait_time_remaining = 5
@@ -147,5 +148,9 @@ module RedisTest
 
     private
     attr_accessor :socket
+
+    def mac?
+      `uname`.downcase.include?('darwin')
+    end
   end
 end

--- a/lib/redis_test/version.rb
+++ b/lib/redis_test/version.rb
@@ -1,3 +1,3 @@
 module RedisTest
-  VERSION = "0.4.0"
+  VERSION = "0.4.1"
 end

--- a/redis_test.gemspec
+++ b/redis_test.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler", "~> 1.17"
   spec.add_development_dependency "byebug"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"


### PR DESCRIPTION
- Fix cannot start Redis server on Linux due to discrepancy in `echo` setting
- Gracefully shutdown server and get rid of annoying core dump message