### PR TITLE
[ready] Fix invalid option passed to redis-server

### DIFF
--- a/lib/redis_test.rb
+++ b/lib/redis_test.rb
@@ -59,8 +59,7 @@ module RedisTest
       redis_options_str = redis_options.map { |k, v| "#{k} #{v}" }.join('\n')
 
       fork do
-        echo_command = mac? ? 'echo' : 'echo -e'
-        system "#{echo_command} '#{redis_options_str}' | redis-server -"
+        system "echo '#{redis_options_str}' | redis-server -"
       end
 
       wait_time_remaining = 5
@@ -149,9 +148,5 @@ module RedisTest
     private
 
     attr_accessor :socket
-
-    def mac?
-      `uname`.downcase.include?('darwin')
-    end
   end
 end

--- a/lib/redis_test/version.rb
+++ b/lib/redis_test/version.rb
@@ -1,3 +1,3 @@
 module RedisTest
-  VERSION = "0.4.1"
+  VERSION = "0.4.2"
 end


### PR DESCRIPTION
In Ubuntu, `system("echo -e 'pidfile hi\n'")` will return `-e 'pidfile hi\n'` (not `'pidfile hi\n'`) as we wanted.
Also, in Ubuntu, we don't need this option since echo can understand `\n` without the -e option.
Since most of our Linux machines use Ubuntu, I guess it's more beneficial if we stick to echo without -e option.

I also propose a story to use docker for our remitano repo to Bug IO team, so that we can reduce those dramas in dev environment later on.